### PR TITLE
set Content-Type header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-- "0.11"
-- "0.10"
+- "0.12"
+- "4"
+- "stable"

--- a/lib/connect-ssi.js
+++ b/lib/connect-ssi.js
@@ -51,6 +51,7 @@ module.exports = function connectSSI(opt) {
         // handle other errors here
         return next(err);
       }
+      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
       res.end(content);
     });
 

--- a/package.json
+++ b/package.json
@@ -34,13 +34,14 @@
   },
   "devDependencies": {
     "express": "^4.10.4",
+    "grunt": "^1.0.1",
     "grunt-cli": "*",
-    "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-nodeunit": "^0.3.3",
-    "grunt-contrib-watch": "^0.6.1",
-    "grunt-mocha-cli": "^1.9.0",
-    "jshint-stylish": "^0.2.0",
-    "load-grunt-tasks": "^0.4.0",
-    "supertest": "^0.15.0"
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-nodeunit": "^1.0.0",
+    "grunt-contrib-watch": "^1.0.0",
+    "grunt-mocha-cli": "^2.1.0",
+    "jshint-stylish": "^2.2.0",
+    "load-grunt-tasks": "^3.5.0",
+    "supertest": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "grunt",
     "Server",
     "Side",
-    "Includes"
+    "Includes",
+    "shtml"
   ],
   "author": "Sönke Kluth <soenke.kluth@gmail.com> (http://soenkekluth.com/)",
   "license": "MIT",

--- a/test/connect-ssi_test.js
+++ b/test/connect-ssi_test.js
@@ -82,4 +82,12 @@ describe('connect-ssi', function() {
             .end(done);
     });
 
+    it('should set a Content-Type header', function(done) {
+        request(app)
+            .get('/index.html')
+            .expect(200)
+            .expect('content-type', 'text/html; charset=UTF-8')
+            .end(done);
+    });
+
 });


### PR DESCRIPTION
Normally browsers just figure it out when content is served without a content-type header, but I recently hit an issue where an intermediate server that I don't control was adding a (usually incorrect) content-type header to any response that didn't have one ...which made me realize that this lib doesn't set one. 

We could make it configurable if you want, but I can't think of any situations where I'd want it to be different from `text/html`.
